### PR TITLE
Require Cabal-version 1.8

### DIFF
--- a/tuple-th.cabal
+++ b/tuple-th.cabal
@@ -8,7 +8,7 @@ Author:              Daniel Schüssler
 Maintainer:          anotheraddress@gmx.de
 Category:            Template Haskell, Data
 Build-type:          Simple
-Cabal-version:       >=1.6
+Cabal-version:       >=1.8
 Extra-source-files:  tests/Test.hs
 Bug-reports:         https://github.com/DanielSchuessler/tuple-th/issues
 


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: tuple-th.cabal:21:30: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```